### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ T大树洞使用GeoIP库进行风控等操作，这里你如果不知道用什�
 go install ./...
 ```
 
-这时会在`$GOROOT/bin`生成几个可执行文件，有用的几个分别是：
+这时会在`$GOPATH/bin`生成几个可执行文件，有用的几个分别是：
 
 `treehollow-v3-push-api`: 用于处理Android和iOS消息推送服务的可执行程序
 


### PR DESCRIPTION
您好！
在编译安装后端的过程中，我发现了本文中可能出现的一个错误，当然，这也有可能是由于我自己对 go 的理解不全面造成的

根据我得到的信息
go install 会在 $GOPATH 下而非 $GOROOT 下产生文件，而将 $GOPATH 设置为 $GOROOT 是无效且不提倡的

同时，我也希望能结合自己搭建过程的经历，对 main 分支上的 install-doc 进行一点完善，便于使用国内云服务提供商的同学搭建树洞。

辛苦！